### PR TITLE
Add support for GNOME 43

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -5,7 +5,8 @@
   "shell-version": [
     "40",
     "41",
-    "42"
+    "42",
+    "43"
   ],
   "url": "https://github.com/PRATAP-KUMAR/Control_Blur_Effect_On_Lock_Screen",
   "uuid": "ControlBlurEffectOnLockScreen@pratap.fastmail.fm",


### PR DESCRIPTION
I've tested this (verrry quickly), and it seems to work.

If anyone wants to test this before merge, you can [download the repo here](https://github.com/Volkor3-16/control-blur-effect-on-lock-screen/archive/refs/heads/gnome-shell-40-41-42.zip) and unzip into  
`/home/$USER/.local/share/gnome-shell/extensions/ControlBlurEffectOnLockScreen@pratap.fastmail.fm/`